### PR TITLE
Add an option to include the URL's query.

### DIFF
--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -30,6 +30,7 @@ func main() {
 
 	http.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
 		logger := logging.GetLogger(r.Context())
+		logging.IncludeRequestQuery(r)
 
 		if r.URL.RawQuery == "error" {
 			logger.Error("error", "err", io.ErrUnexpectedEOF)
@@ -61,7 +62,7 @@ func main() {
 		WriteTimeout: 10 * time.Second,
 		IdleTimeout:  650 * time.Second,
 	}
-	if addr, ok := os.LookupEnv("ADDR"); !ok {
+	if addr, ok := os.LookupEnv("ADDR"); ok {
 		server.Addr = addr
 	}
 	go func() {

--- a/context.go
+++ b/context.go
@@ -11,6 +11,7 @@ type contextKeyLogging int
 const keyLogger = contextKeyLogging(0)
 const keyRequestID = contextKeyLogging(1)
 const keyIgnoredToggle = contextKeyLogging(2)
+const keyIncludeQueryToggle = contextKeyLogging(3)
 
 var noop = slog.New(slog.NewTextHandler(io.Discard, nil))
 

--- a/middleware.go
+++ b/middleware.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"time"
 )
 
 // Middleware wraps the given next http.Handler. Requests made through this
@@ -21,28 +22,37 @@ func Middleware(next http.Handler, logger *slog.Logger) http.Handler {
 		ww := &wrapper{ResponseWriter: w}
 		requestID := "r" + strconv.FormatInt(rand.Int63(), 36)
 		ignored := uint32(0)
+		includeQuery := uint32(0)
 		l := logger.With("rid", requestID)
 
 		ctx := r.Context()
 		ctx = context.WithValue(ctx, keyLogger, l)
 		ctx = context.WithValue(ctx, keyRequestID, requestID)
 		ctx = context.WithValue(ctx, keyIgnoredToggle, &ignored)
+		ctx = context.WithValue(ctx, keyIncludeQueryToggle, &includeQuery)
 		r = r.WithContext(ctx)
 		if r.Header.Get("X-Forwarded-For") != "" {
 			r.RemoteAddr = strings.TrimSpace(strings.Split(r.Header.Get("X-Forwarded-For"), ",")[0])
 		}
 
+		start := time.Now()
 		defer func() {
 			if atomic.LoadUint32(&ignored) != 0 {
 				return
 			}
-			logger.Info("served",
-				"rid", requestID,
-				"method", r.Method,
-				"path", r.URL.Path,
-				"remote", r.RemoteAddr,
-				"status", ww.Status(),
-			)
+			took := time.Since(start)
+			attrs := []slog.Attr{
+				slog.String("rid", requestID),
+				slog.Duration("took", took),
+				slog.String("method", r.Method),
+				slog.String("path", r.URL.Path),
+				slog.String("remote", r.RemoteAddr),
+				slog.Int("status", ww.Status()),
+			}
+			if atomic.LoadUint32(&includeQuery) != 0 && r.URL.RawQuery != "" {
+				attrs = append(attrs, slog.String("query", r.URL.RawQuery))
+			}
+			logger.LogAttrs(ctx, slog.LevelInfo, "served", attrs...)
 		}()
 
 		next.ServeHTTP(ww, r)
@@ -52,6 +62,12 @@ func Middleware(next http.Handler, logger *slog.Logger) http.Handler {
 func IgnoreRequest(r *http.Request) {
 	if ignored, ok := r.Context().Value(keyIgnoredToggle).(*uint32); ok {
 		atomic.StoreUint32(ignored, 1)
+	}
+}
+
+func IncludeRequestQuery(r *http.Request) {
+	if includeQuery, ok := r.Context().Value(keyIncludeQueryToggle).(*uint32); ok {
+		atomic.StoreUint32(includeQuery, 1)
 	}
 }
 


### PR DESCRIPTION
They URL's query parameters are not included by default because that could be considered an privacy or security issue. Thus and per-request option is added to mark a request to include the RawQuery of the URL in question.